### PR TITLE
Issue #1

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
   "io/ioutil"
   "os"
   "math/rand"
+  "time"
 )
 
 type Credentials struct {
@@ -19,6 +20,7 @@ type Credentials struct {
 
 func main() {
   var filename string = "quotes.txt"
+  rand.Seed(time.Now().UTC().UnixNano())
 
   creds := Credentials {
     ConsumerKey : os.Getenv("CONSUMER_KEY"),
@@ -34,12 +36,14 @@ func main() {
 
   quote := getQuote(filename)
 
+  log.Println("Quote Chosen: \""+ quote + "\"")
+
   tweet, resp, err := client.Statuses.Update(quote, nil)
   if err != nil {
       log.Println(err)
   }
-  log.Printf("%+v\n", resp)
   log.Printf("%+v\n", tweet)
+  log.Printf("%+v\n", resp)
 
 }
 


### PR DESCRIPTION
Rand wasn't seeded, as such the same quote was selected repeatedly, causing a duplicate 403 response from twitter.

Seed is now generated based off unix time, and we also log what tweet was chosen.